### PR TITLE
Add support for Vive Wand input in the base dev environment

### DIFF
--- a/lib/logging.fnl
+++ b/lib/logging.fnl
@@ -8,6 +8,7 @@
 (local logs (logging.new-log))
 
 (fn logging.log [level tag message]
+  (print (.. level " " tag " " message))
   (table.insert logs {: level : tag : message})
   ;; There's definitely room for optimization here (e.g. circular buffers), but
   ;; working first, fast later.

--- a/src/form-from-functions.fnl
+++ b/src/form-from-functions.fnl
@@ -107,7 +107,9 @@
         :vive {:physical adapt-physical-vive-touch-input
                  :textual adapt-textual-vive-touch-input}})
 
-(local input-adapter available-input-adapters.vive)
+(local input-adapter (match (lovr.headset.getDriver)
+  :oculus available-input-adapters.oculus
+  :openvr available-input-adapters.vive))
 
 ;; Provide a read-only way for input adapters to query the environment to
 ;; allow them to emit contextual events. These should return booleans so that

--- a/src/form-from-functions.fnl
+++ b/src/form-from-functions.fnl
@@ -108,7 +108,7 @@
                  :textual adapt-textual-vive-touch-input}})
 
 (local input-adapter (match (lovr.headset.getDriver)
-  :oculus available-input-adapters.oculus
+  :vrapi available-input-adapters.oculus
   :openvr available-input-adapters.vive))
 
 ;; Provide a read-only way for input adapters to query the environment to

--- a/src/form-from-functions.fnl
+++ b/src/form-from-functions.fnl
@@ -76,11 +76,38 @@
 (fn adapt-textual-oculus-touch-input [query]
   {:stop (was-pressed :left :y)})
 
+(fn adapt-physical-vive-touch-input [query]
+  {:evaluate (was-pressed :right :touchpad)
+   :save (was-pressed :right :menu)
+   :create-block (and (was-pressed :left :touchpad)
+                      (query.hand-contains-block? :left))
+   :destroy-block (and (was-pressed :left :touchpad)
+                       (not (query.hand-contains-block? :left)))
+   :link (and (or (was-pressed :left :trigger)
+                  (was-pressed :right :trigger))
+              (query.hand-contains-block? :left)
+              (query.hand-contains-block? :right))
+   :grab {:left (was-pressed :left :grip)
+          :right (was-pressed :right :grip)}
+   :clone-grab {:left (and (is-down :left :trigger)
+                           (was-pressed :left :grip))
+                :right (and (is-down :right :trigger)
+                            (was-pressed :right :grip))}
+   :drop {:left (was-released :left :grip)
+          :right (was-released :right :grip)}
+   :write-text (and (was-pressed :left :menu)
+                    (query.hand-contains-block? :left))})
+
+(fn adapt-textual-vive-touch-input [query]
+  {:stop (was-pressed :left :menu)})
+
 (local available-input-adapters
        {:oculus {:physical adapt-physical-oculus-touch-input
-                 :textual adapt-textual-oculus-touch-input}})
+                 :textual adapt-textual-oculus-touch-input}
+        :vive {:physical adapt-physical-vive-touch-input
+                 :textual adapt-textual-vive-touch-input}})
 
-(local input-adapter available-input-adapters.oculus)
+(local input-adapter available-input-adapters.vive)
 
 ;; Provide a read-only way for input adapters to query the environment to
 ;; allow them to emit contextual events. These should return booleans so that

--- a/src/form-from-functions.fnl
+++ b/src/form-from-functions.fnl
@@ -107,9 +107,9 @@
         :vive {:physical adapt-physical-vive-touch-input
                  :textual adapt-textual-vive-touch-input}})
 
-(local input-adapter (match (lovr.headset.getDriver)
-  :vrapi available-input-adapters.oculus
-  :openvr available-input-adapters.vive))
+(local input-adapter (match (lovr.headset.getName)
+  "Oculus Quest" available-input-adapters.oculus
+  "HTC" available-input-adapters.vive))
 
 ;; Provide a read-only way for input adapters to query the environment to
 ;; allow them to emit contextual events. These should return booleans so that


### PR DESCRIPTION
This adds an adapter for Vive Wands in the development environment but does not add any adapters for text input.