### PR TITLE
Make text input extendable/replaceable

### DIFF
--- a/lib/adapters/non-empty-breaker-stack.fnl
+++ b/lib/adapters/non-empty-breaker-stack.fnl
@@ -3,20 +3,26 @@
 
 (local module {})
 
-(fn module.init [default ...]
-  {:default-state (when (and default default.init) (default.init ...))
-   :default-callbacks default
-   :stack (sm.new)})
+(fn module.init [default on-fault ...]
+  (let [{: init} default]
+    {:default-state (when init (init ...))
+     :default-callbacks default
+     :stack (sm.new)
+     : on-fault}))
 
-(fn module.push [{: stack} name layer ...]
-  (sm.push stack name (breaker.init layer #(sm.pop stack name) ...)))
+(fn module.push [{: stack : on-fault} name layer ...]
+  (sm.push stack name
+           (breaker.init layer
+                         #(do (sm.pop stack name)
+                              (when on-fault (on-fault name $...)))
+                         ...)))
 
 (fn module.pop [{: stack} name]
   (sm.pop stack name))
 
 (fn call-through [self callback-name ...]
   (if (< 0 (length self.stack))
-    ((. breaker :callback-name) (sm.top self.stack) ...)
+    ((. breaker callback-name) (sm.top self.stack) ...)
     (match self.default-callbacks
       {callback-name callback} (callback self.default-state ...))))
 
@@ -24,6 +30,6 @@
   (call-through self :update ...))
 
 (fn module.draw [self ...]
-  (call-through self :update ...))
+  (call-through self :draw ...))
 
 module

--- a/lib/adapters/non-empty-breaker-stack.fnl
+++ b/lib/adapters/non-empty-breaker-stack.fnl
@@ -18,7 +18,7 @@
   (if (< 0 (length self.stack))
     ((. breaker :callback-name) (sm.top self.stack) ...)
     (match self.default-callbacks
-      {callback-name callback} (callback self.default-state))))
+      {callback-name callback} (callback self.default-state ...))))
 
 (fn module.update [self ...]
   (call-through self :update ...))

--- a/lib/adapters/non-empty-breaker-stack.fnl
+++ b/lib/adapters/non-empty-breaker-stack.fnl
@@ -1,0 +1,29 @@
+(local sm (require :lib/stacked-map))
+(local breaker (require :lib/adapters/breaker))
+
+(local module {})
+
+(fn module.init [default ...]
+  {:default-state (when (and default default.init) (default.init ...))
+   :default-callbacks default
+   :stack (sm.new)})
+
+(fn module.push [{: stack} name layer ...]
+  (sm.push stack name (breaker.init layer #(sm.pop stack name) ...)))
+
+(fn module.pop [{: stack} name]
+  (sm.pop stack name))
+
+(fn call-through [self callback-name ...]
+  (if (< 0 (length self.stack))
+    ((. breaker :callback-name) (sm.top self.stack) ...)
+    (match self.default-callbacks
+      {callback-name callback} (callback self.default-state))))
+
+(fn module.update [self ...]
+  (call-through self :update ...))
+
+(fn module.draw [self ...]
+  (call-through self :update ...))
+
+module

--- a/lib/stacked-map.fnl
+++ b/lib/stacked-map.fnl
@@ -1,0 +1,37 @@
+;; A stacked-map is a data structure that behaves mostly like a stack, but where
+;; each element also has a name. Elements can be popped off the top or by name,
+;; and if a pushed element uses the same name as an existing item the old one is
+;; removed and the new item is placed on top.
+
+(local module {})
+
+(fn module.new [] {})
+
+(fn module.push [stacked-map key value]
+  (match stacked-map
+    {key index} (do (module.pop stacked-map key)
+                    (module.push stacked-map key value))
+    {key nil} (do (table.insert stacked-map [key value])
+                  (tset stacked-map key (length stacked-map)))))
+
+(fn module.pop [stacked-map key]
+  (when (< 0 (length stacked-map))
+    (if key
+      (let [index (. stacked-map key)
+            [_ value] (. stacked-map index)]
+        (table.remove stacked-map index)
+        (tset stacked-map key nil)
+        value)
+      (let [[key _] (. stacked-map (length stacked-map))]
+        (module.pop stacked-map key)))))
+
+(fn module.top [stacked-map]
+  (match (. stacked-map (length stacked-map))
+    [key value] (values value key)
+    nil nil))
+
+(fn module.clear [stacked-map]
+  (while (< 0 (length stacked-map))
+    (module.pop stacked-map)))
+
+module

--- a/src/development-environment.fnl
+++ b/src/development-environment.fnl
@@ -65,7 +65,8 @@
      :link-type {:left nil
                  :right nil}
      : machine
-     :text-input (non-empty-breaker-stack.init text-input)
+     :text-input (non-empty-breaker-stack.init text-input
+                                               #(log.error :input (debug.traceback (.. "In " $1 " layer: " (tostring $2)))))
      :user-blocks (if (persistence.blocks-file-exists?)
                     (persistence.load-blocks-file)
                     (blocks.init))

--- a/src/development-environment.fnl
+++ b/src/development-environment.fnl
@@ -5,6 +5,7 @@
 (local lxsc (require :third-party/lxsc))
 
 (local binder (require :lib/adapters/binder))
+(local non-empty-breaker-stack (require :lib/adapters/non-empty-breaker-stack))
 (local breaker (require :lib/logging-breaker))
 (local text-input (require :lib/input/layered-radial-text-input))
 (local block (require :lib/block))
@@ -64,7 +65,7 @@
      :link-type {:left nil
                  :right nil}
      : machine
-     :text-input (binder.init breaker text-input)
+     :text-input (non-empty-breaker-stack.init text-input)
      :user-blocks (if (persistence.blocks-file-exists?)
                     (persistence.load-blocks-file)
                     (blocks.init))
@@ -203,7 +204,7 @@
       (set self.hands.left.contents nil))))
 
 (fn textual-update [self dt]
-  (self.text-input:update dt self.text-focus)
+  (non-empty-breaker-stack.update self.text-input dt self.text-focus)
   (match (input-adapter.textual environmental-queries)
     {:stop true} (do (self.machine:fireEvent :change-input-mode)
                      (set self.text-focus nil))))
@@ -260,7 +261,7 @@
       (lovr.graphics.translate 0 0.1 -0.1)
       (lovr.graphics.rotate (- (/ math.pi 4)) 1 0 0)
       (lovr.graphics.scale 0.05)
-      (self.text-input:draw)
+      (non-empty-breaker-stack.draw self.text-input)
       (lovr.graphics.pop))))
 
 (fn development-environment.draw [self]

--- a/src/development-environment.fnl
+++ b/src/development-environment.fnl
@@ -140,7 +140,9 @@
       (match self.user-blocks
         [first-block & _]
         (xpcall
-         (fn [] (set self.user-layer (breaker.init (fennel.eval (generate-code first-block)))))
+         (fn [] (set self.user-layer
+                     (breaker.init (fennel.eval (generate-code first-block))
+                                   {:add-text-input #(non-empty-breaker-stack.push self.text-input $1 $2)})))
          (fn [error]
            (log.error :codegen error)))))
     (when input.save

--- a/test/non-empty-breaker-stack.fnl
+++ b/test/non-empty-breaker-stack.fnl
@@ -1,0 +1,50 @@
+(local breaker-stack (require "lib/adapters/non-empty-breaker-stack"))
+
+(T "A non-empty breaker stack"
+   (fn [T]
+     (T "when created"
+        (fn [T]
+          (T "with extra aguments should pass them through to the default layer"
+             (fn [T]
+               (var arg nil)
+               (breaker-stack.init {:init #(set arg $)} nil "hi")
+               (T:assert (= arg "hi"))))))
+     (T "should pass callbacks through to the default layer when there's nothing on the stack"
+        (fn [T]
+          (var call-count 0)
+          (let [stack (breaker-stack.init {:draw #(set call-count (+ 1 call-count))})]
+            (breaker-stack.draw stack))
+          (T:assert (= call-count 1) (.. "Expected call-count to be 1 but was " call-count))))
+     (T "when there's a layer on the stack"
+        (fn [T]
+          (T "should pass callbacks to top of the stack and to nothing else"
+             (fn [T]
+               (var default-count 0)
+               (var stack-bottom-count 0)
+               (var stack-top-count 0)
+               (let [stack (breaker-stack.init {:update #(set default-count (+ 1 default-count))})]
+                 (doto stack
+                   (breaker-stack.push :bottom {:update #(set stack-bottom-count (+ 1 stack-bottom-count))})
+                   (breaker-stack.push :top {:update #(set stack-top-count (+ 1 stack-top-count))})
+                   (breaker-stack.update)))
+               (T:assert (and (= default-count 0)
+                              (= stack-bottom-count 0)
+                              (= stack-top-count 1)))))
+          (T "and it errors"
+             (fn [T]
+               (T "then the top layer should be popped off"
+                  (fn [T]
+                    (var default-count 0)
+                    (let [stack (breaker-stack.init {:draw #(set default-count (+ 1 default-count))})]
+                      (breaker-stack.push stack :error {:draw #(error "Failed")})
+                      (breaker-stack.draw stack)
+                      (T:assert (= default-count 0) "but the default update was called")
+                      (breaker-stack.draw stack)
+                      (T:assert (= default-count 1) "but it didn't default to the previous layer"))))
+               (T "it should call the provided error handler"
+                  (fn [T]
+                    (var callback-count 0)
+                    (doto (breaker-stack.init {} #(set callback-count 1))
+                      (breaker-stack.push :error {:update #(error "Failed")})
+                      (breaker-stack.update))
+                    (T:assert (= callback-count 1) "but it wasn't called")))))))))

--- a/test/stacked-map.fnl
+++ b/test/stacked-map.fnl
@@ -1,0 +1,60 @@
+(local stacked-map (require :lib/stacked-map))
+
+(T "A stacked map"
+   (fn [T]
+     (local sm (stacked-map.new))
+     (T "when pushing an item"
+        (fn [T]
+          (T "should add it if that key doesn't exist"
+             (fn [T]
+               (stacked-map.push sm :key 23)
+               (T:assert (= (length sm) 1) "but the size didn't increase")
+               (T:assert (= (stacked-map.top sm) 23) "but it wasn't put on top")))
+          (T "that uses an existing key"
+             (fn [T]
+               (T "should replace it"
+                  (fn [T]
+                    (stacked-map.push sm :key 3)
+                    (stacked-map.push sm :key 14)
+                    (T:assert (= (length sm) 1) "but the size changed")
+                    (T:assert (= (stacked-map.top sm) 14) "but the top value wasn't changed")))
+               (T "should bring it to the top"
+                  (fn [T]
+                    (stacked-map.push sm :a 15)
+                    (stacked-map.push sm :b 9)
+                    (stacked-map.push sm :a 26)
+                    (T:assert (= (length sm) 2) "but the size changed")
+                    (T:assert (= (stacked-map.top sm) 26) "but the top value wasn't changed")))))))
+     (T "when popping an item"
+        (fn [T]
+          (T "should do nothing when empty"
+             (fn [T]
+               (stacked-map.pop sm)))
+          (T "should remove the top item if no key is specified"
+             (fn [T]
+               (stacked-map.push sm :a 5)
+               (stacked-map.push sm :b 35)
+               (stacked-map.pop sm)
+               (T:assert (= (length sm) 1) "but the size didn't change as expected")
+               (T:assert (= (stacked-map.top sm) 5) "but the top item wasn't removed")))
+          (T "should remove the named item if a key is specified"
+             (fn [T]
+               (stacked-map.push sm :a 89)
+               (stacked-map.push sm :b 79)
+               (stacked-map.pop sm :a)
+               (T:assert (= (length sm) 1) "but the size didn't change")
+               (T:assert (= (stacked-map.top sm) 79) "but the top item was altered")))
+          (T "should return the popped value"
+             (fn [T]
+               (stacked-map.push sm :a 3)
+               (T:assert (= (stacked-map.pop sm) 3) "but it was something else")))))
+     (T "should remove all items when cleared"
+        (fn [T]
+          (stacked-map.push sm :a 4)
+          (stacked-map.push sm :b 8)
+          (stacked-map.push sm :c 15)
+          (stacked-map.push sm :d 16)
+          (stacked-map.push sm :e 23)
+          (stacked-map.push sm :f 42)
+          (stacked-map.clear sm)
+          (T:assert (= (length sm) 0) "but it didn't")))))


### PR DESCRIPTION
Contributes toward #9 .

Tasks that should be covered by this PR:
- [x] Create a stacked-map type to facilitate named layers so that the stack doesn't get huge if the user keeps adding values to the stack
- [x] Create a non-empty-breaker-stack adapter layer using the stacked-map such that callbacks are passed through to the top layer on the stack or the default layer if none is provided
- [x] Convert the development-environment to use the non-empty-breaker-stack for textual input
- [x] Pass controls to push/pop/clear layers from the text input stack to the user code, likely in the `init` callback
- [x] Log errors in the stacked input modes so the user has a chance of finding and fixing what happened