### PR TITLE
Add a way to undo user-defined text input

### DIFF
--- a/lib/adapters/non-empty-breaker-stack.fnl
+++ b/lib/adapters/non-empty-breaker-stack.fnl
@@ -20,6 +20,9 @@
 (fn module.pop [{: stack} name]
   (sm.pop stack name))
 
+(fn module.clear [{: stack}]
+  (sm.clear stack))
+
 (fn call-through [self callback-name ...]
   (if (< 0 (length self.stack))
     ((. breaker callback-name) (sm.top self.stack) ...)

--- a/lib/input/hotkey.fnl
+++ b/lib/input/hotkey.fnl
@@ -3,7 +3,7 @@
 (local module {})
 
 (fn module.init [detector callback]
-  #(when (detector $...) (callback)))
+  #(when (detector $...) (callback $...)))
 
 (fn module.update [self ...]
   (self ...))


### PR DESCRIPTION
This will be added to as other parts of the development environment
become available for the user to modify. The gesture recognition isn't
particularly great - I was going for a thumbs-down gesture - but it
works well enough for now. It can be refined later to be more natural.

Closes #9 .